### PR TITLE
Add cookie-opt-in for CAPTCHA skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cornchan
 [![Build Status](https://travis-ci.com/lurkshark/cornchan.svg?branch=master)](https://travis-ci.com/lurkshark/cornchan)
+[![W3C Validation](https://img.shields.io/w3c-validation/html?targetUrl=https%3A%2F%2Fcornchan.org%2Fcorn%2F)](https://validator.nu/?doc=https%3A%2F%2Fcornchan.org%2Fcorn%2F)
 
 ## Development
 The guiding principle of this project is to have a well-tested piece of garbage. The implementation should be a single PHP file with as few functions, classes, or otherwise good things as possible. This doesn't mean that it should be insecure or buggy; the end product should be solid.

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -22,6 +22,7 @@ input[type=checkbox] { width: inherit; }
 textarea { height: 200px; }
 button { width: 90%; }
 
+#captcha-answer { text-transform: uppercase; }
 label[for=opt-in-cookie] {
   font-size: smaller;
   font-weight: lighter;

--- a/test/spec/10_board_new_spec.rb
+++ b/test/spec/10_board_new_spec.rb
@@ -12,7 +12,7 @@ feature "Posting a new thread to a board" do
       within("#newthread") do
         fill_in "lorem", with: subject
         fill_in "ipsum", with: message
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -29,7 +29,7 @@ feature "Posting a new thread to a board" do
       within("#newthread") do
         fill_in "lorem", with: subject
         fill_in "ipsum", with: message
-        fill_in "amet", with: "GARBAGE"
+        fill_in "captcha-answer", with: "GARBAGE"
         click_button "Submit"
       end
     end
@@ -57,7 +57,7 @@ feature "Posting a new thread to a board" do
     background do
       within("#newthread") do
         fill_in "ipsum", with: message
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -72,7 +72,7 @@ feature "Posting a new thread to a board" do
     background do
       within("#newthread") do
         fill_in "lorem", with: subject
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -80,6 +80,38 @@ feature "Posting a new thread to a board" do
     scenario "redirects to the board and shows the new subject-only post" do
       expect(page).to have_current_path("/corn/")
       expect(page).to have_content(subject)
+    end
+  end
+
+  context "when the captcha cookie opt-in is checked" do
+    background do
+      within("#newthread") do
+        fill_in "lorem", with: subject
+        fill_in "captcha-answer", with: captcha
+        check "opt-in-cookie"
+        click_button "Submit"
+      end
+    end
+
+    scenario "redirects to the board and doesn't prompt for a CAPTCHA" do
+      expect(page).to have_current_path("/corn/")
+      expect(page).to_not have_content("CAPTCHA")
+    end
+  end
+
+  context "when the captcha cookie opt-in is unchecked" do
+    background do
+      within("#newthread") do
+        fill_in "lorem", with: subject
+        fill_in "captcha-answer", with: captcha
+        uncheck "opt-in-cookie"
+        click_button "Submit"
+      end
+    end
+
+    scenario "redirects to the board and prompts for a CAPTCHA" do
+      expect(page).to have_current_path("/corn/")
+      expect(page).to have_content("CAPTCHA")
     end
   end
 end

--- a/test/spec/20_thread_new_spec.rb
+++ b/test/spec/20_thread_new_spec.rb
@@ -12,7 +12,7 @@ feature "Posting a new reply to a thread" do
       within("#newreply") do
         fill_in "lorem", with: subject
         fill_in "ipsum", with: message
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -29,7 +29,7 @@ feature "Posting a new reply to a thread" do
       within("#newreply") do
         fill_in "lorem", with: subject
         fill_in "ipsum", with: message
-        fill_in "amet", with: "GARBAGE"
+        fill_in "captcha-answer", with: "GARBAGE"
         click_button "Submit"
       end
     end
@@ -57,7 +57,7 @@ feature "Posting a new reply to a thread" do
     background do
       within("#newreply") do
         fill_in "ipsum", with: message
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -72,7 +72,7 @@ feature "Posting a new reply to a thread" do
     background do
       within("#newreply") do
         fill_in "lorem", with: subject
-        fill_in "amet", with: captcha
+        fill_in "captcha-answer", with: captcha
         click_button "Submit"
       end
     end
@@ -80,6 +80,38 @@ feature "Posting a new reply to a thread" do
     scenario "redirects to the thread and shows the new subject-only post" do
       expect(page).to have_current_path("/corn/10000")
       expect(page).to have_content(subject)
+    end
+  end
+
+  context "when the captcha cookie opt-in is checked" do
+    background do
+      within("#newreply") do
+        fill_in "lorem", with: subject
+        fill_in "captcha-answer", with: captcha
+        check "opt-in-cookie"
+        click_button "Submit"
+      end
+    end
+
+    scenario "redirects to the board and doesn't prompt for a CAPTCHA" do
+      expect(page).to have_current_path("/corn/10000")
+      expect(page).to_not have_content("CAPTCHA")
+    end
+  end
+
+  context "when the captcha cookie opt-in is unchecked" do
+    background do
+      within("#newreply") do
+        fill_in "lorem", with: subject
+        fill_in "captcha-answer", with: captcha
+        uncheck "opt-in-cookie"
+        click_button "Submit"
+      end
+    end
+
+    scenario "redirects to the board and prompts for a CAPTCHA" do
+      expect(page).to have_current_path("/corn/10000")
+      expect(page).to have_content("CAPTCHA")
     end
   end
 end


### PR DESCRIPTION
#37 This change allows users to opt-in to a cookie that skips subsequent CPATCHA challenges for an hour.