### PR TITLE
Show all thread replies on board

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -8,6 +8,17 @@ hr {
   border-top: 1px solid;
 }
 
+.thread, .reply {
+  overflow: visible;
+  word-break: break-word;
+}
+.reply {
+  background-color: #f3f3f3;
+  display: inline-block;
+  padding: 0.25em 0.5em;
+  margin: 0.25em 0;
+}
+
 .post-subject {
   font-size: 1em;
   margin: 0;

--- a/test/spec/20_posting_new_reply_spec.rb
+++ b/test/spec/20_posting_new_reply_spec.rb
@@ -1,12 +1,10 @@
 feature "Posting a new reply to a thread" do
-  given(:subject) { lorem_ipsum(5) }
   given(:message) { lorem_ipsum(64) }
   given(:captcha) { "GOODCAPTCHA" }
 
   background do
     visit "/corn/t/1000"
     within("#new-post") do
-      fill_in "subject", with: subject
       fill_in "message", with: message
       fill_in "captcha_answer", with: captcha
       click_button "Submit"
@@ -16,29 +14,19 @@ feature "Posting a new reply to a thread" do
   context "when the form is fully filled-out" do
     scenario "redirects to the thread and shows the new reply" do
       expect(page).to have_current_path("/corn/t/1000")
-      expect(page).to have_content(subject)
-      expect(page).to have_content(message)
-    end
-  end
-
-  context "when the subject is empty" do
-    given(:subject) { "" }
-    scenario "redirects to the thread and shows the new message-only post" do
-      expect(page).to have_current_path("/corn/t/1000")
       expect(page).to have_content(message)
     end
   end
 
   context "when the message is empty" do
     given(:message) { "" }
-    scenario "redirects to the thread and shows the new subject-only post" do
-      expect(page).to have_current_path("/corn/t/1000")
-      expect(page).to have_content(subject)
+    scenario "fails to post the new reply and stays on the publish path" do
+      expect(page).to have_current_path("/corn/t/1000/publish")
     end
   end
 
-  xscenario "bumps the thread being replied-to" do
+  scenario "shows the reply on the board" do
     visit "/corn/"
-    expect(page).to have_content(/1000.*1001/)
+    expect(page).to have_content(message)
   end
 end


### PR DESCRIPTION
#36 This change shows all the replies to each thread on the board page. A follow-up should probably limit this to the past n replies.