### PR TITLE
Add post tags for pseudonymous replying

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -28,4 +28,4 @@ https://raw.githubusercontent.com/lurkshark/cornchan/master/src/static/wild.css
 EOF
 
 # Nuke DB while still testing
-# rm /home/protected/cornchan.db
+rm /home/protected/cornchan.db

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -23,6 +23,14 @@ hr {
   font-size: 1em;
   margin: 0.25em 0;
 }
+.post-tag {
+  font-size: 0.85em;
+}
+.post-tag-segment {
+  display: inline-block;
+  height: 0.85em;
+  width: 0.35em;
+}
 .post-time {
   font-size: 0.8em;
 }
@@ -55,6 +63,10 @@ hr {
 #new-post textarea,
 #new-post button {
   grid-column: 2 / 3;
+  padding: 0.25em;
+}
+#new-post textarea {
+  height: 8em;
 }
 #captcha-answer {
   text-transform: uppercase;

--- a/src/static/wild.css
+++ b/src/static/wild.css
@@ -15,8 +15,8 @@ body {
 .title {}
 .thread {}
 .reply {
-  background-color: #fcfcfc;
-  border: 1px solid #cfcfcf;
+  background-color: #f9f9f9;
+  border: 1px solid #9f9f9f;
   border-radius: 3px;
 }
 .post-details {}
@@ -24,6 +24,9 @@ body {
 .post-id {
   text-decoration: none;
   color: #ccad00;
+}
+.post-tag {
+  opacity: 0.85;
 }
 .post-name {
   font-style: italic;


### PR DESCRIPTION
#60 This change adds a visual tag to posts that represent an IP address. They are keyed on IP+ThreadID so they do not carry from one thread to another.