### PR TITLE
Make tests a bit more resilient

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -137,12 +137,13 @@ function render_new_post_form_fragment_html($board_or_thread, $prefill = array()
 }
 
 function render_post_tag_fragment_html($post_tag) {
-  $hashed = hash('sha256', $post_tag);
+  $tags = array_map(function($hex_chunk) {
+    return 'hsl(' . (hexdec($hex_chunk) % 24) * 15 . ', 100%, 50%)';
+  }, str_split(hash('sha256', $post_tag), 8));
   ob_start(); ?>
-    <span class="post-tag-segment" style="background-color: #<?php echo substr($hashed, 0, 6); ?>;">
-    </span><span class="post-tag-segment" style="background-color: #<?php echo substr($hashed, 6, 6); ?>;">
-    </span><span class="post-tag-segment" style="background-color: #<?php echo substr($hashed, 12, 6); ?>;">
-    </span><span class="post-tag-segment" style="background-color: #<?php echo substr($hashed, 18, 6); ?>;">
+    <span class="post-tag-segment" style="background-color: <?php echo $tags[0]; ?>;">
+    </span><span class="post-tag-segment" style="background-color: <?php echo $tags[1]; ?>;">
+    </span><span class="post-tag-segment" style="background-color: <?php echo $tags[2]; ?>;">
     </span>
   <?php return ob_get_clean(); // margin:0;
 }
@@ -339,6 +340,7 @@ function put_reply_data($db_w, $reply) { global $config;
 function put_thread_data($db_w, $thread) { global $config;
   $board_id = $thread['board_id'];
   if (!in_array($board_id, $config['board_ids'])) return false;
+  if (empty(trim($thread['subject'])) && empty(trim($thread['message']))) return false;
 
   $thread_id = fresh_id($db_w);
   $thread_key = $board_id . '#' . $thread_id;

--- a/src/static/wild.css
+++ b/src/static/wild.css
@@ -25,9 +25,6 @@ body {
   text-decoration: none;
   color: #ccad00;
 }
-.post-tag {
-  opacity: 0.85;
-}
 .post-name {
   font-style: italic;
   color: #5d943b;

--- a/test/spec/10_posting_new_thread_spec.rb
+++ b/test/spec/10_posting_new_thread_spec.rb
@@ -15,7 +15,7 @@ feature "Posting a new thread to a board" do
 
   context "when the form is fully filled-out" do
     scenario "redirects to the new thread" do
-      expect(page).to have_current_path("/corn/t/1000")
+      expect(page).to have_current_path(/\/corn\/t\/\d+/)
       expect(page).to have_content(subject)
       expect(page).to have_content(message)
     end
@@ -24,8 +24,23 @@ feature "Posting a new thread to a board" do
   context "when the message is empty" do
     given(:message) { "" }
     scenario "redirects to the new subject-only post" do
-      expect(page).to have_current_path("/corn/t/1001")
+      expect(page).to have_current_path(/\/corn\/t\/\d+/)
       expect(page).to have_content(subject)
+    end
+  end
+
+  context "when the subject and message are empty" do
+    given(:subject) { "" }
+    given(:message) { "" }
+    scenario "fails to post the new thread and stays on the publish path" do
+      expect(page).to have_current_path("/corn/publish")
+    end
+  end
+
+  context "when the captcha is wrong" do
+    given(:captcha) { "BADCAPTCHA" }
+    scenario "fails to post the new thread and stays on the publish path" do
+      expect(page).to have_current_path("/corn/publish")
     end
   end
 end

--- a/test/spec/15_visiting_thread_spec.rb
+++ b/test/spec/15_visiting_thread_spec.rb
@@ -1,18 +1,22 @@
 feature "Visiting a thread" do
-  background do
-    # These tests depend on thread_new_spec
-    visit "/corn/t/1000"
+  given(:thread_id) do
+    page.current_path.match(/\/corn\/t\/(\d+)/)[1]
   end
 
-  scenario "has the board and thread name" do
+  background do
+    visit "/corn/"
+    first(".thread a.post-id").click
+  end
+
+  scenario "has the board and thread id" do
     expect(page).to have_content("corn")
-    expect(page).to have_content("1000")
+    expect(page).to have_content(thread_id)
   end
 
   scenario "has a form for posting a new thread" do
     within("#new-post") do
       # Let thread_new_spec handle the details
-      expect(find("form")["action"]).to eq("#{Capybara.app_host}/corn/t/1000/publish")
+      expect(find("form")["action"]).to eq("#{Capybara.app_host}/corn/t/#{thread_id}/publish")
     end
   end
 end

--- a/test/spec/20_posting_new_reply_spec.rb
+++ b/test/spec/20_posting_new_reply_spec.rb
@@ -1,9 +1,13 @@
 feature "Posting a new reply to a thread" do
   given(:message) { lorem_ipsum(64) }
   given(:captcha) { "GOODCAPTCHA" }
+  given(:thread_id) do
+    page.current_path.match(/\/corn\/t\/(\d+)/)[1]
+  end
 
   background do
-    visit "/corn/t/1000"
+    visit "/corn/"
+    first(".thread a.post-id").click
     within("#new-post") do
       fill_in "message", with: message
       fill_in "captcha_answer", with: captcha
@@ -13,7 +17,7 @@ feature "Posting a new reply to a thread" do
 
   context "when the form is fully filled-out" do
     scenario "redirects to the thread and shows the new reply" do
-      expect(page).to have_current_path("/corn/t/1000")
+      expect(page).to have_current_path("/corn/t/#{thread_id}")
       expect(page).to have_content(message)
     end
   end
@@ -21,7 +25,7 @@ feature "Posting a new reply to a thread" do
   context "when the message is empty" do
     given(:message) { "" }
     scenario "fails to post the new reply and stays on the publish path" do
-      expect(page).to have_current_path("/corn/t/1000/publish")
+      expect(page).to have_current_path("/corn/t/#{thread_id}/publish")
     end
   end
 


### PR DESCRIPTION
This change removes some of the hardcoded thread ID checks so the tests are more resilient.