### PR TITLE
Write files to HOME for NFSN

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -29,3 +29,5 @@ EOF
 
 # Nuke DB while still testing
 rm /home/protected/cornchan.db
+rm /home/protected/config.php
+

--- a/src/index.php
+++ b/src/index.php
@@ -3,7 +3,7 @@ $config = array(); // CORNCHAN
 define('CORN_VERSION', '0.7.1');
 header('X-Powered-By: Corn v' . CORN_VERSION);
 $config['test_override'] = isset($_ENV['CORN_TEST_OVERRIDE']);
-$config['config_location'] = $config['test_override'] ? '/tmp' : $_SERVER['DOCUMENT_ROOT'];
+$config['config_location'] = $config['test_override'] ? '/tmp' : $_ENV['HOME'];
 $config['installed'] = @include($config['config_location'] . '/config.php');
 
 $db = $config['installed'] ? dba_open(CORN_DBA_PATH, 'r', CORN_DBA_HANDLER) : NULL;


### PR DESCRIPTION
This change should probably be switched-up depending on how common the permissions setup NFSN has is. Since NFSN doesn't allow writing to the DOCUMENT_ROOT by default, the file-modification tests fail.